### PR TITLE
DM-13725: Source Sans/Code Typography

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 lsst-sphinx-bootstrap-theme Changelog
 =====================================
 
+0.1.2 (2018-03-08)
+------------------
+
+- Switch to Source Sans and Source Code Pro from Adobe, via typekit.com.
+- Larger font (16 px), narrower measure, slightly tighter leading.
+- H2s now have overlines, not underlines.
+- Remove outline around inline code samples; retain background hint.
+
 0.1 (2016-12-14)
 ----------------
 

--- a/lsst_sphinx_bootstrap_theme/layout.html
+++ b/lsst_sphinx_bootstrap_theme/layout.html
@@ -5,8 +5,8 @@
 
 {# Add the google webfonts needed for the logo #}
 {% block extrahead %}
-{# jonathansick's lsst-sphinx-bootstrap-theme typekit kit #}
-<script src="https://use.typekit.net/eme3dgn.js"></script>
+{# Jonathan Sick's lsst-sphinx-bootstrap-source typekit theme #}
+<link rel="stylesheet" href="https://use.typekit.net/isi7ftn.css">
 <script>try{Typekit.load({ async: true });}catch(e){}</script>
 {% if not embedded %}<script type="text/javascript" src="{{ pathto('_static/copybutton.js', 1) }}"></script>{% endif %}
 

--- a/lsst_sphinx_bootstrap_theme/static/bootstrap-astropy.css
+++ b/lsst_sphinx_bootstrap_theme/static/bootstrap-astropy.css
@@ -126,12 +126,6 @@ code, pre, tt {
   font-size: 1.0em;
   font-weight: 400;
 }
-code, pre {
-  padding: 0 3px 2px;
-  -webkit-border-radius: 3px;
-  -moz-border-radius: 3px;
-  border-radius: 3px;
-}
 code {
   padding: 1px 3px;
 }
@@ -151,15 +145,6 @@ pre {
 
 img {
   margin: 9px 0;
-}
-
-/* format inline code with a rounded box */
-tt, code {
-    margin: 0 2px;
-    padding: 0 5px;
-    border: 1px solid #ddd;
-    border: 1px solid rgba(0, 0, 0, 0.12);
-    border-radius: 3px;
 }
 
 code.xref, a code {

--- a/lsst_sphinx_bootstrap_theme/static/bootstrap-astropy.css
+++ b/lsst_sphinx_bootstrap_theme/static/bootstrap-astropy.css
@@ -14,7 +14,7 @@
 body {
   background-color: #ffffff;
   margin: 0;
-  font-family: "ff-meta-web-pro", "Helvetica Neue", "Helvetica", sans-serif;
+  font-family: "source-sans-pro", "Helvetica Neue", "Helvetica", sans-serif;
   font-weight: 400;
   font-style: normal;
   font-size: 14px;
@@ -112,7 +112,7 @@ hr {
 }
 strong {
   font-style: inherit;
-  font-weight: bold;
+  font-weight: 700;
 }
 em {
   font-style: italic;
@@ -129,8 +129,9 @@ address {
   margin-bottom: 18px;
 }
 code, pre, tt {
-  font-family: "hack", "Menlo", monospace;
-  font-size: 0.9em;
+  font-family: "source-code-pro", "Menlo", monospace;
+  font-size: 1.0em;
+  font-weight: 400;
 }
 code, pre {
   padding: 0 3px 2px;
@@ -193,7 +194,7 @@ tt.xref, a tt, tt.descname, tt.descclassname {
   border: none;
   padding: 0 1px 0 1px;
   background-color: transparent;
-  font-weight: bold;
+  font-weight: 700;
 }
 
 th {
@@ -236,7 +237,7 @@ div.topbar {
 div.topbar a.brand {
   font-size: 26px;
   color: #ffffff;
-  font-weight: 600;
+  font-weight: 700;
   text-decoration: none;
   float: left;
   display: block;
@@ -318,8 +319,9 @@ div.topbar form {
 div.topbar input {
   background-color: #444;
   background-color: rgba(255, 255, 255, 0.3);
-  font-size: normal;
-  font-weight: 13px;
+  font-style: normal;
+  font-size: 13px;
+  font-weight: 400;
   line-height: 1;
   padding: 4px 9px;
   color: #ffffff;
@@ -418,14 +420,14 @@ div.sphinxsidebarwrapper {
 
 div.sphinxsidebar h3 {
     font-size: 1.4em;
-    font-weight: normal;
+    font-weight: 400;
     margin: 5px 0px 0px 5px;
     padding: 0;
     line-height: 1.6em;
 }
 div.sphinxsidebar h4 {
     font-size: 1.3em;
-    font-weight: normal;
+    font-weight: 400;
     margin: 5px 0 0 0;
     padding: 0;
 }
@@ -517,7 +519,7 @@ div.warning p.admonition-title {
     margin: 0;
     padding: 0.1em 0 0.1em 0.5em;
     color: white;
-    font-weight: bold;
+    font-weight: 700;
     font-size: 1.1em;
 }
 div.admonition ul, div.admonition ol,

--- a/lsst_sphinx_bootstrap_theme/static/bootstrap-astropy.css
+++ b/lsst_sphinx_bootstrap_theme/static/bootstrap-astropy.css
@@ -396,7 +396,7 @@ footer {
 /* Sphinx sidebar ------------------------------------------------------------*/
 
 div.sphinxsidebar {
-    font-size: inherit;
+    font-size: 0.9em;
     border-radius: 3px;
     background-color: #eee;
     border: 1px solid #bbb;

--- a/lsst_sphinx_bootstrap_theme/static/bootstrap-astropy.css
+++ b/lsst_sphinx_bootstrap_theme/static/bootstrap-astropy.css
@@ -17,8 +17,8 @@ body {
   font-family: "source-sans-pro", "Helvetica Neue", "Helvetica", sans-serif;
   font-weight: 400;
   font-style: normal;
-  font-size: 14px;
-  line-height: 1.5;
+  font-size: 16px;
+  line-height: 1.4;
   color: #404040;
 }
 
@@ -41,7 +41,7 @@ a:hover {
 h1,h2,h3,h4,h5,h6 {
   color: #404040;
   margin: 0.7em 0 0 0;
-  line-height: 1.5em;
+  line-height: 1.3;
 }
 h1 {
   font-size: 24px;
@@ -49,7 +49,6 @@ h1 {
 }
 h2 {
   font-size: 21px;
-  line-height: 1.2em;
   margin: 1em 0 0.5em 0;
   border-bottom: 1px solid #404040;
 }
@@ -68,11 +67,8 @@ h6 {
 }
 
 p {
-  font-size: 14px;
-  font-weight: normal;
-  line-height: 1.5;
-  margin-top: 0px;
-  margin-bottom: 9px;
+  margin-top: 0;
+  margin-bottom: 1em;
 }
 
 ul, ol {
@@ -89,7 +85,6 @@ ol {
   list-style: decimal;
 }
 li {
-  line-height: 18px;
   color: #404040;
 }
 ul.unstyled {
@@ -98,9 +93,6 @@ ul.unstyled {
 }
 dl {
   margin-bottom: 18px;
-}
-dl dt, dl dd {
-  line-height: 18px;
 }
 dl dd {
   margin-left: 9px;
@@ -125,7 +117,7 @@ em {
 
 address {
   display: block;
-  line-height: 18px;
+  line-height: 1.2;
   margin-bottom: 18px;
 }
 code, pre, tt {
@@ -146,7 +138,7 @@ pre {
   display: block;
   padding: 8.5px;
   margin: 0 0 18px;
-  line-height: 18px;
+  line-height: 1.2;
   border: 1px solid #ddd;
   border: 1px solid rgba(0, 0, 0, 0.12);
   -webkit-border-radius: 3px;
@@ -476,7 +468,7 @@ div.body {
 
 div.bodywrapper {
     margin: 0 0 0 230px;
-    max-width: 55em;
+    max-width: 40em;
 }
 
 

--- a/lsst_sphinx_bootstrap_theme/static/bootstrap-astropy.css
+++ b/lsst_sphinx_bootstrap_theme/static/bootstrap-astropy.css
@@ -50,7 +50,8 @@ h1 {
 h2 {
   font-size: 21px;
   margin: 1em 0 0.5em 0;
-  border-bottom: 1px solid #404040;
+  border-top: 1px solid #404040;
+  padding-top: 0.5em;
 }
 h3 {
   font-size: 18px;

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup
 
 NAME = 'lsst-sphinx-bootstrap-theme'
-VERSION = '0.1.1'
+VERSION = '0.1.2'
 
 
 setup(


### PR DESCRIPTION
Tweaks the the bootstrap theme to use Adobe Source Sans and Source Code Pro instead of FF Meta as the base font. Also tweak the line length and leading for readability.

![screen shot 2018-03-07 at 8 29 42 pm](https://user-images.githubusercontent.com/349384/37133206-af4c9dbe-2246-11e8-9f82-917d2ec02d87.png)
